### PR TITLE
Add fallback model options and hybrid retrieval module

### DIFF
--- a/initialize.py
+++ b/initialize.py
@@ -1,4 +1,6 @@
 from agent import AgentConfig
+import re
+
 import models
 from python.helpers import runtime, settings, defer
 from python.helpers.print_style import PrintStyle
@@ -25,6 +27,15 @@ def initialize_agent():
                 result[key] = value
         return result
 
+    def _parse_fallbacks(raw_value):
+        if not raw_value:
+            return []
+        if isinstance(raw_value, list):
+            candidates = raw_value
+        else:
+            candidates = re.split(r"[\n,]+", str(raw_value))
+        return [candidate.strip() for candidate in candidates if candidate and candidate.strip()]
+
     # chat model from user settings
     chat_llm = models.ModelConfig(
         type=models.ModelType.CHAT,
@@ -37,6 +48,7 @@ def initialize_agent():
         limit_input=current_settings["chat_model_rl_input"],
         limit_output=current_settings["chat_model_rl_output"],
         kwargs=_normalize_model_kwargs(current_settings["chat_model_kwargs"]),
+        fallbacks=_parse_fallbacks(current_settings.get("chat_model_fallbacks", "")),
     )
 
     # utility model from user settings
@@ -50,6 +62,7 @@ def initialize_agent():
         limit_input=current_settings["util_model_rl_input"],
         limit_output=current_settings["util_model_rl_output"],
         kwargs=_normalize_model_kwargs(current_settings["util_model_kwargs"]),
+        fallbacks=_parse_fallbacks(current_settings.get("util_model_fallbacks", "")),
     )
     # embedding model from user settings
     embedding_llm = models.ModelConfig(
@@ -68,6 +81,7 @@ def initialize_agent():
         api_base=current_settings["browser_model_api_base"],
         vision=current_settings["browser_model_vision"],
         kwargs=_normalize_model_kwargs(current_settings["browser_model_kwargs"]),
+        fallbacks=_parse_fallbacks(current_settings.get("browser_model_fallbacks", "")),
     )
     # agent configuration
     config = AgentConfig(

--- a/models.py
+++ b/models.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 import logging
 import os
+from dataclasses import dataclass, field, replace
+from enum import Enum
 from typing import (
     Any,
     Awaitable,
@@ -26,6 +28,8 @@ from python.helpers.providers import get_provider_config
 from python.helpers.rate_limiter import RateLimiter
 from python.helpers.tokens import approximate_tokens
 from python.helpers import dirty_json, browser_use_monkeypatch
+
+logger = logging.getLogger(__name__)
 
 from langchain_core.language_models.chat_models import SimpleChatModel
 from langchain_core.outputs.chat_generation import ChatGenerationChunk
@@ -76,6 +80,7 @@ class ModelConfig:
     limit_input: int = 0
     limit_output: int = 0
     vision: bool = False
+    fallbacks: list[str] = field(default_factory=list)
     kwargs: dict = field(default_factory=dict)
 
     def build_kwargs(self):
@@ -83,6 +88,19 @@ class ModelConfig:
         if self.api_base and "api_base" not in kwargs:
             kwargs["api_base"] = self.api_base
         return kwargs
+
+    def candidate_sequence(self) -> list[str]:
+        seen: set[str] = set()
+        sequence: list[str] = []
+        for candidate in [self.name, *self.fallbacks]:
+            clean = (candidate or "").strip()
+            if clean and clean not in seen:
+                seen.add(clean)
+                sequence.append(clean)
+        return sequence
+
+    def with_name(self, name: str) -> "ModelConfig":
+        return replace(self, name=name)
 
 
 class ChatChunk(TypedDict):
@@ -309,6 +327,14 @@ class LiteLLMChatWrapper(SimpleChatModel):
         super().__init__(model_name=model_value, provider=provider, kwargs=kwargs)  # type: ignore
         # Set A0 model config as instance attribute after parent init
         self.a0_model_conf = model_config
+        self._model_candidates = (
+            model_config.candidate_sequence() if model_config else [model]
+        )
+        if not self._model_candidates:
+            self._model_candidates = [model]
+        self._primary_model = self._model_candidates[0]
+        self._last_successful_model = self._primary_model
+        self.model_name = self._format_model_name(self._primary_model)
 
     @property
     def _llm_type(self) -> str:
@@ -362,6 +388,43 @@ class LiteLLMChatWrapper(SimpleChatModel):
             result.append(message_dict)
         return result
 
+    def _model_sequence(self) -> List[str]:
+        return list(self._model_candidates)
+
+    def _format_model_name(self, candidate: str) -> str:
+        candidate = (candidate or "").strip()
+        if not candidate:
+            return self.model_name
+        return f"{self.provider}/{candidate}" if self.provider else candidate
+
+    def _candidate_config(self, candidate: str) -> Optional[ModelConfig]:
+        if not self.a0_model_conf:
+            return None
+        if candidate == self.a0_model_conf.name:
+            return self.a0_model_conf
+        return self.a0_model_conf.with_name(candidate)
+
+    def _log_fallback(
+        self, failed_model: str, exc: Exception, next_model: Optional[str]
+    ) -> None:
+        if next_model:
+            logger.warning(
+                "Model %s failed (%s). Falling back to %s",
+                failed_model,
+                getattr(exc, "status_code", repr(exc)),
+                next_model,
+            )
+        else:
+            logger.warning(
+                "Model %s failed (%s) and no fallback model is available",
+                failed_model,
+                getattr(exc, "status_code", repr(exc)),
+            )
+
+    def _update_successful_model(self, candidate: str) -> None:
+        self._last_successful_model = candidate
+        self.model_name = self._format_model_name(candidate)
+
     def _call(
         self,
         messages: List[BaseMessage],
@@ -369,22 +432,44 @@ class LiteLLMChatWrapper(SimpleChatModel):
         run_manager: Optional[CallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> str:
-        import asyncio
-
         msgs = self._convert_messages(messages)
+        call_kwargs: dict[str, Any] = {**self.kwargs, **kwargs}
+        last_exc: Exception | None = None
+        candidates = self._model_sequence()
 
-        # Apply rate limiting if configured
-        apply_rate_limiter_sync(self.a0_model_conf, str(msgs))
+        for idx, candidate in enumerate(candidates):
+            candidate_name = self._format_model_name(candidate)
+            candidate_config = self._candidate_config(candidate)
 
-        # Call the model
-        resp = completion(
-            model=self.model_name, messages=msgs, stop=stop, **{**self.kwargs, **kwargs}
-        )
+            apply_rate_limiter_sync(candidate_config, str(msgs))
 
-        # Parse output
-        parsed = _parse_chunk(resp)
-        output = ChatGenerationResult(parsed).output()
-        return output["response_delta"]
+            result = ChatGenerationResult()
+            try:
+                resp = completion(
+                    model=candidate_name,
+                    messages=msgs,
+                    stop=stop,
+                    **call_kwargs,
+                )
+                parsed = _parse_chunk(resp)
+                output = result.add_chunk(parsed)
+                self._update_successful_model(candidate)
+                return output["response_delta"]
+            except Exception as exc:
+                last_exc = exc
+                next_model = (
+                    self._format_model_name(candidates[idx + 1])
+                    if idx < len(candidates) - 1
+                    else None
+                )
+                self._log_fallback(candidate_name, exc, next_model)
+                if next_model:
+                    continue
+                raise
+
+        if last_exc:
+            raise last_exc
+        return ""
 
     def _stream(
         self,
@@ -393,31 +478,50 @@ class LiteLLMChatWrapper(SimpleChatModel):
         run_manager: Optional[CallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> Iterator[ChatGenerationChunk]:
-        import asyncio
-
         msgs = self._convert_messages(messages)
+        call_kwargs: dict[str, Any] = {**self.kwargs, **kwargs}
+        candidates = self._model_sequence()
+        last_exc: Exception | None = None
 
-        # Apply rate limiting if configured
-        apply_rate_limiter_sync(self.a0_model_conf, str(msgs))
+        for idx, candidate in enumerate(candidates):
+            candidate_name = self._format_model_name(candidate)
+            candidate_config = self._candidate_config(candidate)
+            apply_rate_limiter_sync(candidate_config, str(msgs))
 
-        result = ChatGenerationResult()
+            result = ChatGenerationResult()
+            try:
+                for chunk in completion(
+                    model=candidate_name,
+                    messages=msgs,
+                    stream=True,
+                    stop=stop,
+                    **call_kwargs,
+                ):
+                    parsed = _parse_chunk(chunk)
+                    output = result.add_chunk(parsed)
 
-        for chunk in completion(
-            model=self.model_name,
-            messages=msgs,
-            stream=True,
-            stop=stop,
-            **{**self.kwargs, **kwargs},
-        ):
-            # parse chunk
-            parsed = _parse_chunk(chunk) # chunk parsing
-            output = result.add_chunk(parsed) # chunk processing
-
-            # Only yield chunks with non-None content
-            if output["response_delta"]:
-                yield ChatGenerationChunk(
-                    message=AIMessageChunk(content=output["response_delta"])
+                    if output["response_delta"]:
+                        yield ChatGenerationChunk(
+                            message=AIMessageChunk(content=output["response_delta"])
+                        )
+                self._update_successful_model(candidate)
+                return
+            except Exception as exc:
+                last_exc = exc
+                if result.response or result.reasoning:
+                    raise
+                next_model = (
+                    self._format_model_name(candidates[idx + 1])
+                    if idx < len(candidates) - 1
+                    else None
                 )
+                self._log_fallback(candidate_name, exc, next_model)
+                if next_model:
+                    continue
+                raise
+
+        if last_exc:
+            raise last_exc
 
     async def _astream(
         self,
@@ -427,29 +531,50 @@ class LiteLLMChatWrapper(SimpleChatModel):
         **kwargs: Any,
     ) -> AsyncIterator[ChatGenerationChunk]:
         msgs = self._convert_messages(messages)
+        call_kwargs: dict[str, Any] = {**self.kwargs, **kwargs}
+        candidates = self._model_sequence()
+        last_exc: Exception | None = None
 
-        # Apply rate limiting if configured
-        await apply_rate_limiter(self.a0_model_conf, str(msgs))
+        for idx, candidate in enumerate(candidates):
+            candidate_name = self._format_model_name(candidate)
+            candidate_config = self._candidate_config(candidate)
+            await apply_rate_limiter(candidate_config, str(msgs))
 
-        result = ChatGenerationResult()
-
-        response = await acompletion(
-            model=self.model_name,
-            messages=msgs,
-            stream=True,
-            stop=stop,
-            **{**self.kwargs, **kwargs},
-        )
-        async for chunk in response:  # type: ignore
-            # parse chunk
-            parsed = _parse_chunk(chunk) # chunk parsing
-            output = result.add_chunk(parsed) # chunk processing
-
-            # Only yield chunks with non-None content
-            if output["response_delta"]:
-                yield ChatGenerationChunk(
-                    message=AIMessageChunk(content=output["response_delta"])
+            result = ChatGenerationResult()
+            try:
+                response = await acompletion(
+                    model=candidate_name,
+                    messages=msgs,
+                    stream=True,
+                    stop=stop,
+                    **call_kwargs,
                 )
+                async for chunk in response:  # type: ignore
+                    parsed = _parse_chunk(chunk)
+                    output = result.add_chunk(parsed)
+
+                    if output["response_delta"]:
+                        yield ChatGenerationChunk(
+                            message=AIMessageChunk(content=output["response_delta"])
+                        )
+                self._update_successful_model(candidate)
+                return
+            except Exception as exc:
+                last_exc = exc
+                if result.response or result.reasoning:
+                    raise
+                next_model = (
+                    self._format_model_name(candidates[idx + 1])
+                    if idx < len(candidates) - 1
+                    else None
+                )
+                self._log_fallback(candidate_name, exc, next_model)
+                if next_model:
+                    continue
+                raise
+
+        if last_exc:
+            raise last_exc
 
     async def unified_call(
         self,
@@ -477,87 +602,114 @@ class LiteLLMChatWrapper(SimpleChatModel):
 
         # convert to litellm format
         msgs_conv = self._convert_messages(messages)
-
-        # Apply rate limiting if configured
-        limiter = await apply_rate_limiter(
-            self.a0_model_conf, str(msgs_conv), rate_limiter_callback
-        )
-
-        # Prepare call kwargs and retry config (strip A0-only params before calling LiteLLM)
         call_kwargs: dict[str, Any] = {**self.kwargs, **kwargs}
         max_retries: int = int(call_kwargs.pop("a0_retry_attempts", 2))
         retry_delay_s: float = float(call_kwargs.pop("a0_retry_delay_seconds", 1.5))
-        stream = reasoning_callback is not None or response_callback is not None or tokens_callback is not None
+        stream = (
+            reasoning_callback is not None
+            or response_callback is not None
+            or tokens_callback is not None
+        )
 
-        # results
-        result = ChatGenerationResult()
+        candidates = self._model_sequence()
+        last_exc: Exception | None = None
 
-        attempt = 0
-        while True:
-            got_any_chunk = False
-            try:
-                # call model
-                _completion = await acompletion(
-                    model=self.model_name,
-                    messages=msgs_conv,
-                    stream=stream,
-                    **call_kwargs,
-                )
+        for idx, candidate in enumerate(candidates):
+            candidate_name = self._format_model_name(candidate)
+            candidate_config = self._candidate_config(candidate)
+            limiter = await apply_rate_limiter(
+                candidate_config, str(msgs_conv), rate_limiter_callback
+            )
 
-                if stream:
-                    # iterate over chunks
-                    async for chunk in _completion:  # type: ignore
-                        got_any_chunk = True
-                        # parse chunk
-                        parsed = _parse_chunk(chunk)
+            result = ChatGenerationResult()
+            attempt = 0
+            while True:
+                got_any_chunk = False
+                try:
+                    _completion = await acompletion(
+                        model=candidate_name,
+                        messages=msgs_conv,
+                        stream=stream,
+                        **call_kwargs,
+                    )
+
+                    if stream:
+                        async for chunk in _completion:  # type: ignore
+                            got_any_chunk = True
+                            parsed = _parse_chunk(chunk)
+                            output = result.add_chunk(parsed)
+
+                            if output["reasoning_delta"]:
+                                if reasoning_callback:
+                                    await reasoning_callback(
+                                        output["reasoning_delta"], result.reasoning
+                                    )
+                                if tokens_callback:
+                                    await tokens_callback(
+                                        output["reasoning_delta"],
+                                        approximate_tokens(output["reasoning_delta"]),
+                                    )
+                                if limiter:
+                                    limiter.add(
+                                        output=approximate_tokens(
+                                            output["reasoning_delta"]
+                                        )
+                                    )
+                            if output["response_delta"]:
+                                if response_callback:
+                                    await response_callback(
+                                        output["response_delta"], result.response
+                                    )
+                                if tokens_callback:
+                                    await tokens_callback(
+                                        output["response_delta"],
+                                        approximate_tokens(output["response_delta"]),
+                                    )
+                                if limiter:
+                                    limiter.add(
+                                        output=approximate_tokens(
+                                            output["response_delta"]
+                                        )
+                                    )
+                    else:
+                        parsed = _parse_chunk(_completion)
                         output = result.add_chunk(parsed)
-
-                        # collect reasoning delta and call callbacks
-                        if output["reasoning_delta"]:
-                            if reasoning_callback:
-                                await reasoning_callback(output["reasoning_delta"], result.reasoning)
-                            if tokens_callback:
-                                await tokens_callback(
-                                    output["reasoning_delta"],
-                                    approximate_tokens(output["reasoning_delta"]),
+                        if limiter:
+                            if output["response_delta"]:
+                                limiter.add(
+                                    output=approximate_tokens(output["response_delta"])
                                 )
-                            # Add output tokens to rate limiter if configured
-                            if limiter:
-                                limiter.add(output=approximate_tokens(output["reasoning_delta"]))
-                        # collect response delta and call callbacks
-                        if output["response_delta"]:
-                            if response_callback:
-                                await response_callback(output["response_delta"], result.response)
-                            if tokens_callback:
-                                await tokens_callback(
-                                    output["response_delta"],
-                                    approximate_tokens(output["response_delta"]),
+                            if output["reasoning_delta"]:
+                                limiter.add(
+                                    output=approximate_tokens(output["reasoning_delta"])
                                 )
-                            # Add output tokens to rate limiter if configured
-                            if limiter:
-                                limiter.add(output=approximate_tokens(output["response_delta"]))
 
-                # non-stream response
-                else:
-                    parsed = _parse_chunk(_completion)
-                    output = result.add_chunk(parsed)
-                    if limiter:
-                        if output["response_delta"]:
-                            limiter.add(output=approximate_tokens(output["response_delta"]))
-                        if output["reasoning_delta"]:
-                            limiter.add(output=approximate_tokens(output["reasoning_delta"]))
+                    self._update_successful_model(candidate)
+                    return result.response, result.reasoning
 
-                # Successful completion of stream
-                return result.response, result.reasoning
+                except Exception as e:
+                    import asyncio
 
-            except Exception as e:
-                import asyncio
-                
-                # Retry only if no chunks received and error is transient
-                if got_any_chunk or not _is_transient_litellm_error(e) or attempt >= max_retries:
-                    raise
-                attempt += 1
-                await asyncio.sleep(retry_delay_s)
+                    if got_any_chunk or not _is_transient_litellm_error(e) or attempt >= max_retries:
+                        last_exc = e
+                        break
+                    attempt += 1
+                    await asyncio.sleep(retry_delay_s)
+
+            next_model = (
+                self._format_model_name(candidates[idx + 1])
+                if idx < len(candidates) - 1
+                else None
+            )
+            if last_exc:
+                self._log_fallback(candidate_name, last_exc, next_model)
+            if next_model:
+                continue
+            if last_exc:
+                raise last_exc
+
+        if last_exc:
+            raise last_exc
 
 
 class AsyncAIChatReplacement:

--- a/models.py
+++ b/models.py
@@ -389,7 +389,12 @@ class LiteLLMChatWrapper(SimpleChatModel):
         return result
 
     def _model_sequence(self) -> List[str]:
-        return list(self._model_candidates)
+        candidates = list(self._model_candidates)
+        last_successful = getattr(self, "_last_successful_model", None)
+        if last_successful and last_successful in candidates:
+            candidates.remove(last_successful)
+            candidates.insert(0, last_successful)
+        return candidates
 
     def _format_model_name(self, candidate: str) -> str:
         candidate = (candidate or "").strip()

--- a/prompts/agent.system.user-preferences.md
+++ b/prompts/agent.system.user-preferences.md
@@ -1,0 +1,3 @@
+This default user preferences prompt is appended after the main system prompt.
+Customize it from Settings > System Prompts to describe tone, recurring goals, or boundaries.
+You can replace it entirely by clearing the settings field and providing your own text.

--- a/python/helpers/settings.py
+++ b/python/helpers/settings.py
@@ -20,6 +20,7 @@ class Settings(TypedDict):
 
     chat_model_provider: str
     chat_model_name: str
+    chat_model_fallbacks: str
     chat_model_api_base: str
     chat_model_kwargs: dict[str, Any]
     chat_model_ctx_length: int
@@ -31,6 +32,7 @@ class Settings(TypedDict):
 
     util_model_provider: str
     util_model_name: str
+    util_model_fallbacks: str
     util_model_api_base: str
     util_model_kwargs: dict[str, Any]
     util_model_ctx_length: int
@@ -48,6 +50,7 @@ class Settings(TypedDict):
 
     browser_model_provider: str
     browser_model_name: str
+    browser_model_fallbacks: str
     browser_model_api_base: str
     browser_model_vision: bool
     browser_model_rl_requests: int
@@ -196,6 +199,16 @@ def convert_out(settings: Settings) -> SettingsOutput:
 
     chat_model_fields.append(
         {
+            "id": "chat_model_fallbacks",
+            "title": "Fallback model name(s)",
+            "description": "Optional backup models from the same provider. Provide one per line or comma separated; fallbacks are used if the primary model returns an API error.",
+            "type": "text",
+            "value": settings["chat_model_fallbacks"],
+        }
+    )
+
+    chat_model_fields.append(
+        {
             "id": "chat_model_api_base",
             "title": "Chat model API base URL",
             "description": "API base URL for main chat model. Leave empty for default. Only relevant for Azure, local and custom (other) providers.",
@@ -304,6 +317,16 @@ def convert_out(settings: Settings) -> SettingsOutput:
             "description": "Exact name of model from selected provider",
             "type": "text",
             "value": settings["util_model_name"],
+        }
+    )
+
+    util_model_fields.append(
+        {
+            "id": "util_model_fallbacks",
+            "title": "Utility fallback model name(s)",
+            "description": "Optional backup models from the same provider. Provide one per line or comma separated.",
+            "type": "text",
+            "value": settings["util_model_fallbacks"],
         }
     )
 
@@ -460,6 +483,16 @@ def convert_out(settings: Settings) -> SettingsOutput:
             "description": "Exact name of model from selected provider",
             "type": "text",
             "value": settings["browser_model_name"],
+        }
+    )
+
+    browser_model_fields.append(
+        {
+            "id": "browser_model_fallbacks",
+            "title": "Web Browser fallback model name(s)",
+            "description": "Optional backup models from the same provider. Provide one per line or comma separated.",
+            "type": "text",
+            "value": settings["browser_model_fallbacks"],
         }
     )
 
@@ -1504,6 +1537,7 @@ def get_default_settings() -> Settings:
         version=_get_version(),
         chat_model_provider="openrouter",
         chat_model_name="openai/gpt-4.1",
+        chat_model_fallbacks="",
         chat_model_api_base="",
         chat_model_kwargs={"temperature": "0"},
         chat_model_ctx_length=100000,
@@ -1514,6 +1548,7 @@ def get_default_settings() -> Settings:
         chat_model_rl_output=0,
         util_model_provider="openrouter",
         util_model_name="openai/gpt-4.1-mini",
+        util_model_fallbacks="",
         util_model_api_base="",
         util_model_ctx_length=100000,
         util_model_ctx_input=0.7,
@@ -1529,6 +1564,7 @@ def get_default_settings() -> Settings:
         embed_model_rl_input=0,
         browser_model_provider="openrouter",
         browser_model_name="openai/gpt-4.1",
+        browser_model_fallbacks="",
         browser_model_api_base="",
         browser_model_vision=True,
         browser_model_rl_requests=0,

--- a/python/tools/code_execution_tool.py
+++ b/python/tools/code_execution_tool.py
@@ -17,7 +17,7 @@ import re
 CODE_EXEC_TIMEOUTS: dict[str, int] = {
     "first_output_timeout": 30,
     "between_output_timeout": 15,
-    "max_exec_timeout": 180,
+    "max_exec_timeout": 900,
     "dialog_timeout": 5,
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ docker==7.1.0
 duckduckgo-search==6.1.12
 faiss-cpu==1.11.0
 neo4j==5.26.0
-fastmcp==2.3.4
+fastmcp==2.13.0.2
 fasta2a==0.5.0
 flask[async]==3.0.3
 flask-basicauth==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ langchain-unstructured[all-docs]==0.1.6
 openai-whisper==20240930
 lxml_html_clean==0.3.1
 markdown==3.7
-mcp==1.13.1
+mcp==1.17.0
 newspaper3k==0.2.8
 paramiko==3.5.0
 playwright==1.52.0

--- a/retrieval/__init__.py
+++ b/retrieval/__init__.py
@@ -1,0 +1,17 @@
+"""Hybrid retrieval package."""
+
+from .hybrid import (
+    HybridRetrievalConfig,
+    HybridRetrievalResult,
+    HybridRetriever,
+    QueryPlan,
+    RetrievedSegment,
+)
+
+__all__ = [
+    "HybridRetrievalConfig",
+    "HybridRetrievalResult",
+    "HybridRetriever",
+    "QueryPlan",
+    "RetrievedSegment",
+]

--- a/retrieval/hybrid.py
+++ b/retrieval/hybrid.py
@@ -1,0 +1,478 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, TYPE_CHECKING
+
+import faiss
+import numpy as np
+from langchain_core.documents import Document
+
+from python.helpers.tokens import approximate_tokens
+
+if TYPE_CHECKING:  # pragma: no cover - import cycles guard
+    from agent import Agent
+    from python.helpers.vector_db import VectorDB
+    from python.helpers.neo4j_memory import Neo4jMemory
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class HybridRetrievalConfig:
+    """Configuration for the hybrid retriever."""
+
+    top_k: int = 8
+    graph_hops: int = 2
+    graph_branching: int = 4
+    rerank_top_k: int = 12
+    token_budget: int = 1400
+    reranker: str = "hybrid"  # "hybrid", "utility", or "none"
+    reranker_model: str = ""
+    ivf_nlist: int = 100
+    pq_m: int = 16
+    pq_bits: int = 8
+    min_train_vectors: int = 64
+    min_similarity: float = 0.0
+
+
+@dataclass
+class QueryPlan:
+    """Expanded query plan used during retrieval."""
+
+    original_query: str
+    rewritten_queries: List[str] = field(default_factory=list)
+    keywords: List[str] = field(default_factory=list)
+
+
+@dataclass
+class RetrievedSegment:
+    """Final retrieval payload segment."""
+
+    id: str
+    content: str
+    score: float
+    metadata: Dict[str, Any]
+    source: str
+    hop: int
+    dom_path: Optional[str] = None
+    screenshot: Optional[str] = None
+
+
+@dataclass
+class HybridRetrievalResult:
+    """Aggregate result returned by :class:`HybridRetriever`."""
+
+    query: str
+    plan: QueryPlan
+    segments: List[RetrievedSegment]
+
+
+@dataclass
+class _Candidate:
+    """Internal representation of a retrieval candidate."""
+
+    doc_id: str
+    document: Document
+    score: float
+    hop: int = 0
+    keywords_matched: int = 0
+
+
+class HybridRetriever:
+    """Perform hybrid (vector + graph) retrieval with optional reranking."""
+
+    def __init__(
+        self,
+        agent: Optional["Agent"],
+        vector_store: "VectorDB",
+        graph_store: Optional["Neo4jMemory"],
+        *,
+        config: Optional[HybridRetrievalConfig] = None,
+        query_rewriter: Optional[Callable[[str], Awaitable[QueryPlan]]] = None,
+    ) -> None:
+        self.agent = agent
+        self.vector_store = vector_store
+        self.graph_store = graph_store
+        self.config = config or HybridRetrievalConfig()
+        self._query_rewriter = query_rewriter
+        self._pq_index: Optional[faiss.IndexIDMap] = None
+        self._pq_docs: List[Document] = []
+        self._pq_total: int = 0
+        self._index_lock = asyncio.Lock()
+
+    async def retrieve(self, query: str) -> HybridRetrievalResult:
+        """Execute the full hybrid retrieval pipeline for ``query``."""
+
+        start = time.perf_counter()
+        plan = await self._rewrite_query(query)
+        base_results = await self._vector_search(plan)
+        expanded = await self._expand_graph(base_results, plan)
+        ranked = await self._rerank_candidates(expanded, query, plan)
+        segments = self._package_segments(ranked)
+        elapsed = time.perf_counter() - start
+        logger.debug("Hybrid retrieval for '%s' completed in %.2f s", query, elapsed)
+        return HybridRetrievalResult(query=query, plan=plan, segments=segments)
+
+    async def _rewrite_query(self, query: str) -> QueryPlan:
+        if self._query_rewriter:
+            try:
+                plan = await self._query_rewriter(query)
+                if plan.rewritten_queries:
+                    return plan
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("Custom query rewriter failed: %s", exc)
+
+        if self.agent:
+            try:
+                plan = await self._rewrite_with_agent(query)
+                if plan.rewritten_queries:
+                    return plan
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("Utility model query rewrite failed: %s", exc)
+
+        return self._heuristic_plan(query)
+
+    async def _rewrite_with_agent(self, query: str) -> QueryPlan:
+        assert self.agent  # for type checker
+        system_prompt = (
+            "You expand search queries for a retrieval engine. Respond in JSON with the keys "
+            "'expansions', 'boolean', and 'keywords'. 'expansions' is a list of rewritten "
+            "queries, 'boolean' is an optional boolean expression string, and 'keywords' is a "
+            "list of important keywords."
+        )
+        response = await self.agent.call_utility_model(system=system_prompt, message=query)
+        plan = self._parse_rewrite_response(query, response)
+        if plan.rewritten_queries:
+            return plan
+        return self._heuristic_plan(query)
+
+    def _parse_rewrite_response(self, original: str, text: str) -> QueryPlan:
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            return QueryPlan(original_query=original)
+
+        expansions: List[str] = []
+        keywords: List[str] = []
+
+        if isinstance(data, dict):
+            boolean_expr = data.get("boolean")
+            if isinstance(boolean_expr, str) and boolean_expr.strip():
+                expansions.append(boolean_expr.strip())
+            raw_expansions = data.get("expansions")
+            if isinstance(raw_expansions, list):
+                expansions.extend(str(item).strip() for item in raw_expansions if str(item).strip())
+            raw_keywords = data.get("keywords")
+            if isinstance(raw_keywords, list):
+                keywords = [str(item).strip() for item in raw_keywords if str(item).strip()]
+        elif isinstance(data, list):
+            expansions.extend(str(item).strip() for item in data if str(item).strip())
+
+        expansions = self._deduplicate([original] + expansions)
+        return QueryPlan(original_query=original, rewritten_queries=expansions, keywords=self._deduplicate(keywords))
+
+    def _heuristic_plan(self, query: str) -> QueryPlan:
+        tokens = re.findall(r"[\w-]+", query.lower())
+        keywords = [tok for tok in tokens if len(tok) > 2]
+        boolean_expr = " AND ".join(f'"{kw}"' for kw in keywords) if keywords else ""
+        expansions = [query]
+        if boolean_expr:
+            expansions.append(boolean_expr)
+        return QueryPlan(
+            original_query=query,
+            rewritten_queries=self._deduplicate(expansions),
+            keywords=self._deduplicate(keywords),
+        )
+
+    async def _ensure_ann_index(self) -> None:
+        async with self._index_lock:
+            docs_map = getattr(self.vector_store.db, "get_all_docs", lambda: {})()
+            docs = list(docs_map.values())
+            total = len(docs)
+            if total < self.config.min_train_vectors:
+                self._pq_index = None
+                self._pq_docs = docs
+                self._pq_total = total
+                return
+
+            if self._pq_index is not None and self._pq_total == total:
+                return
+
+            embeddings: List[List[float]] = []
+            for doc in docs:
+                text = doc.page_content or ""
+                embeddings.append(self.vector_store.embeddings.embed_query(text))
+
+            matrix = np.asarray(embeddings, dtype="float32")
+            if matrix.size == 0:
+                self._pq_index = None
+                self._pq_docs = docs
+                self._pq_total = total
+                return
+
+            nlist = min(self.config.ivf_nlist, max(1, total // 2))
+            quantizer = faiss.IndexFlatIP(matrix.shape[1])
+            try:
+                pq = faiss.IndexIVFPQ(quantizer, matrix.shape[1], nlist, self.config.pq_m, self.config.pq_bits)
+                pq.train(matrix)
+                id_map = faiss.IndexIDMap(pq)
+                ids = np.arange(total, dtype="int64")
+                id_map.add_with_ids(matrix, ids)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("Failed to prepare PQ index, falling back to exact search: %s", exc)
+                self._pq_index = None
+                self._pq_docs = docs
+                self._pq_total = total
+                return
+
+            self._pq_index = id_map
+            self._pq_docs = docs
+            self._pq_total = total
+
+    async def _vector_search(self, plan: QueryPlan) -> List[_Candidate]:
+        await self._ensure_ann_index()
+        aggregated: Dict[str, _Candidate] = {}
+        queries = plan.rewritten_queries or [plan.original_query]
+
+        for variant in queries:
+            vector = None
+            try:
+                vector = self.vector_store.embeddings.embed_query(variant)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("Embedding query failed: %s", exc)
+                continue
+
+            if self._pq_index is not None and self._pq_docs:
+                scores, indices = self._pq_index.search(np.asarray([vector], dtype="float32"), self.config.top_k)
+                for score, idx in zip(scores[0], indices[0]):
+                    if idx == -1:
+                        continue
+                    base_doc = self._pq_docs[idx]
+                    doc = Document(page_content=base_doc.page_content, metadata=dict(base_doc.metadata))
+                    doc_id = str(doc.metadata.get("id", idx))
+                    candidate = aggregated.get(doc_id)
+                    normalized = float(score)
+                    if candidate is None or normalized > candidate.score:
+                        aggregated[doc_id] = _Candidate(
+                            doc_id=doc_id,
+                            document=doc,
+                            score=normalized,
+                            hop=0,
+                            keywords_matched=self._count_keyword_matches(doc.page_content, plan.keywords),
+                        )
+            else:
+                results = await self.vector_store.search_by_similarity_threshold(
+                    variant,
+                    limit=self.config.top_k,
+                    threshold=self.config.min_similarity,
+                )
+                for rank, doc in enumerate(results):
+                    doc_copy = Document(page_content=doc.page_content, metadata=dict(doc.metadata))
+                    doc_id = str(doc_copy.metadata.get("id", rank))
+                    score = float(doc_copy.metadata.get("score") or doc_copy.metadata.get("relevance_score") or (1.0 - rank / max(1, self.config.top_k)))
+                    candidate = aggregated.get(doc_id)
+                    if candidate is None or score > candidate.score:
+                        aggregated[doc_id] = _Candidate(
+                            doc_id=doc_id,
+                            document=doc_copy,
+                            score=score,
+                            hop=0,
+                            keywords_matched=self._count_keyword_matches(doc_copy.page_content, plan.keywords),
+                        )
+
+        return sorted(aggregated.values(), key=lambda item: item.score, reverse=True)[: self.config.top_k]
+
+    async def _expand_graph(self, base: List[_Candidate], plan: QueryPlan) -> List[_Candidate]:
+        if not self.graph_store:
+            return base
+
+        expanded: Dict[str, _Candidate] = {candidate.doc_id: candidate for candidate in base}
+        keywords = plan.keywords
+
+        for candidate in base:
+            node_id = candidate.doc_id
+            queue: List[_Candidate] = [candidate]
+            seen = {node_id}
+
+            while queue:
+                current_candidate = queue.pop(0)
+                current_id = current_candidate.doc_id
+                if current_candidate.hop >= self.config.graph_hops:
+                    continue
+                try:
+                    neighbors = await self.graph_store.get_related_entities(current_id, limit=self.config.graph_branching)
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.warning("Graph expansion failed for %s: %s", current_id, exc)
+                    break
+
+                for neighbor in neighbors:
+                    neighbor_id = str(neighbor.get("id"))
+                    if not neighbor_id or neighbor_id in seen:
+                        continue
+                    seen.add(neighbor_id)
+                    metadata = dict(neighbor)
+                    content = metadata.pop("content", "")
+                    hop = current_candidate.hop + 1
+                    base_score = max(0.0, current_candidate.score * (0.8 - 0.1 * current_candidate.hop))
+                    match_count = self._count_keyword_matches(content, keywords)
+                    score = base_score + (0.02 * match_count)
+                    metadata.setdefault("id", neighbor_id)
+                    doc = Document(page_content=content, metadata=metadata)
+                    new_candidate = _Candidate(
+                        doc_id=neighbor_id,
+                        document=doc,
+                        score=score,
+                        hop=hop,
+                        keywords_matched=match_count,
+                    )
+                    expanded[neighbor_id] = new_candidate
+                    queue.append(new_candidate)
+
+        return list(expanded.values())
+
+    async def _rerank_candidates(
+        self,
+        candidates: List[_Candidate],
+        query: str,
+        plan: QueryPlan,
+    ) -> List[_Candidate]:
+        if not candidates:
+            return []
+
+        for candidate in candidates:
+            hop_bonus = 0.0
+            if candidate.hop == 0:
+                hop_bonus = 0.05
+            elif candidate.hop == 1:
+                hop_bonus = 0.03
+            elif candidate.hop == 2:
+                hop_bonus = 0.01
+            candidate.score = candidate.score + hop_bonus + (0.02 * candidate.keywords_matched)
+
+        candidates.sort(key=lambda item: item.score, reverse=True)
+
+        reranker_mode = self.config.reranker.lower()
+        if reranker_mode == "utility" and self.agent:
+            try:
+                candidates = await self._rerank_with_utility(candidates, query)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("Utility reranker failed: %s", exc)
+        elif reranker_mode == "none":
+            pass
+
+        return sorted(candidates, key=lambda item: item.score, reverse=True)[: self.config.rerank_top_k]
+
+    async def _rerank_with_utility(self, candidates: List[_Candidate], query: str) -> List[_Candidate]:
+        assert self.agent  # for type checker
+        sample = candidates[: self.config.rerank_top_k]
+        payload = {
+            "query": query,
+            "segments": [
+                {
+                    "id": cand.doc_id,
+                    "hop": cand.hop,
+                    "score": cand.score,
+                    "content": (cand.document.page_content or "")[:5000],
+                    "metadata": cand.document.metadata,
+                }
+                for cand in sample
+            ],
+        }
+        system_prompt = (
+            "Return JSON with a 'scores' list containing objects with keys 'id' and 'score'. "
+            "Higher scores indicate higher relevance."
+        )
+        response = await self.agent.call_utility_model(system=system_prompt, message=json.dumps(payload))
+        mapping = self._parse_rerank_scores(response)
+        if not mapping:
+            return candidates
+
+        for candidate in candidates:
+            if candidate.doc_id in mapping:
+                candidate.score = float(mapping[candidate.doc_id])
+        return sorted(candidates, key=lambda item: item.score, reverse=True)
+
+    def _parse_rerank_scores(self, text: str) -> Dict[str, float]:
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            return {}
+
+        if isinstance(data, dict):
+            scores = data.get("scores")
+        else:
+            scores = data
+
+        result: Dict[str, float] = {}
+        if isinstance(scores, list):
+            for entry in scores:
+                if isinstance(entry, dict) and "id" in entry and "score" in entry:
+                    doc_id = str(entry["id"]).strip()
+                    try:
+                        result[doc_id] = float(entry["score"])
+                    except (TypeError, ValueError):  # pragma: no cover - defensive
+                        continue
+        return result
+
+    def _package_segments(self, candidates: List[_Candidate]) -> List[RetrievedSegment]:
+        if not candidates:
+            return []
+
+        budget = max(0, int(self.config.token_budget))
+        used_tokens = 0
+        packaged: List[RetrievedSegment] = []
+
+        for candidate in sorted(candidates, key=lambda item: item.score, reverse=True):
+            content = candidate.document.page_content or ""
+            token_cost = approximate_tokens(content)
+            if budget and used_tokens + token_cost > budget and packaged:
+                break
+            used_tokens += token_cost
+            metadata = dict(candidate.document.metadata)
+            metadata.update(
+                {
+                    "score": candidate.score,
+                    "hop": candidate.hop,
+                    "keywords_matched": candidate.keywords_matched,
+                }
+            )
+            dom_path = metadata.get("dom_path") or metadata.get("domPath")
+            screenshot = metadata.get("screenshot") or metadata.get("screenshot_url")
+            source = metadata.get("source") or metadata.get("document_uri") or "vector"
+            packaged.append(
+                RetrievedSegment(
+                    id=str(metadata.get("id", candidate.doc_id)),
+                    content=content,
+                    score=candidate.score,
+                    metadata=metadata,
+                    source=str(source),
+                    hop=candidate.hop,
+                    dom_path=dom_path,
+                    screenshot=screenshot,
+                )
+            )
+
+        return packaged
+
+    @staticmethod
+    def _deduplicate(items: Iterable[str]) -> List[str]:
+        seen: set[str] = set()
+        result: List[str] = []
+        for item in items:
+            clean = item.strip()
+            if clean and clean not in seen:
+                seen.add(clean)
+                result.append(clean)
+        return result
+
+    @staticmethod
+    def _count_keyword_matches(text: str, keywords: Sequence[str]) -> int:
+        if not text or not keywords:
+            return 0
+        lowered = text.lower()
+        return sum(1 for keyword in keywords if keyword.lower() in lowered)

--- a/tests/dependency_stubs.py
+++ b/tests/dependency_stubs.py
@@ -1,0 +1,398 @@
+"""Minimal stubs for optional third-party dependencies used in tests."""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+import numpy as np
+
+
+def install_dependency_stubs() -> None:
+    """Inject lightweight stand-ins for optional runtime dependencies.
+
+    These stubs provide just enough surface area for imports to succeed
+    without pulling large native libraries into the test environment.
+    """
+
+    if "cryptography" not in sys.modules:
+        crypto_module = types.ModuleType("cryptography")
+        hazmat_module = types.ModuleType("cryptography.hazmat")
+        primitives_module = types.ModuleType("cryptography.hazmat.primitives")
+        asymmetric_module = types.ModuleType("cryptography.hazmat.primitives.asymmetric")
+        rsa_module = types.ModuleType("cryptography.hazmat.primitives.asymmetric.rsa")
+        padding_module = types.ModuleType("cryptography.hazmat.primitives.asymmetric.padding")
+        hashes_module = types.ModuleType("cryptography.hazmat.primitives.hashes")
+        serialization_module = types.ModuleType("cryptography.hazmat.primitives.serialization")
+
+        class _DummySHA256:
+            def __call__(self) -> "_DummySHA256":
+                return self
+
+        class _DummyMGF1:
+            def __init__(self, algorithm: Any):
+                self.algorithm = algorithm
+
+        class _DummyOAEP:
+            def __init__(self, mgf: Any, algorithm: Any, label: Any):
+                self.mgf = mgf
+                self.algorithm = algorithm
+                self.label = label
+
+        class _DummyPublicKey:
+            def public_bytes(self, encoding: Any = None, format: Any = None) -> bytes:
+                return b""
+
+            def encrypt(self, data: bytes, pad: Any) -> bytes:
+                return b""
+
+        class _DummyPrivateKey(_DummyPublicKey):
+            def public_key(self) -> "_DummyPublicKey":
+                return _DummyPublicKey()
+
+            def decrypt(self, data: bytes, pad: Any) -> bytes:
+                return b""
+
+        class RSAPrivateKey(_DummyPrivateKey):
+            pass
+
+        class RSAPublicKey(_DummyPublicKey):
+            pass
+
+        def generate_private_key(public_exponent: int, key_size: int) -> RSAPrivateKey:
+            return RSAPrivateKey()
+
+        rsa_module.RSAPrivateKey = RSAPrivateKey
+        rsa_module.RSAPublicKey = RSAPublicKey
+        rsa_module.generate_private_key = generate_private_key
+
+        padding_module.MGF1 = _DummyMGF1
+        padding_module.OAEP = _DummyOAEP
+
+        hashes_module.SHA256 = _DummySHA256
+
+        class _Encoding:
+            PEM = "PEM"
+
+        class _PublicFormat:
+            SubjectPublicKeyInfo = "SubjectPublicKeyInfo"
+
+        def load_pem_public_key(data: bytes) -> RSAPublicKey:
+            return RSAPublicKey()
+
+        serialization_module.Encoding = _Encoding
+        serialization_module.PublicFormat = _PublicFormat
+        serialization_module.load_pem_public_key = load_pem_public_key
+
+        asymmetric_module.rsa = rsa_module
+        asymmetric_module.padding = padding_module
+
+        primitives_module.asymmetric = asymmetric_module
+        primitives_module.hashes = hashes_module
+        primitives_module.serialization = serialization_module
+
+        hazmat_module.primitives = primitives_module
+        crypto_module.hazmat = hazmat_module
+
+        sys.modules["cryptography"] = crypto_module
+        sys.modules["cryptography.hazmat"] = hazmat_module
+        sys.modules["cryptography.hazmat.primitives"] = primitives_module
+        sys.modules["cryptography.hazmat.primitives.asymmetric"] = asymmetric_module
+        sys.modules["cryptography.hazmat.primitives.asymmetric.rsa"] = rsa_module
+        sys.modules["cryptography.hazmat.primitives.asymmetric.padding"] = padding_module
+        sys.modules["cryptography.hazmat.primitives.hashes"] = hashes_module
+        sys.modules["cryptography.hazmat.primitives.serialization"] = serialization_module
+
+    if "browser_use" not in sys.modules:
+        browser_use = types.ModuleType("browser_use")
+        llm_module = types.ModuleType("browser_use.llm")
+
+        class _BaseChat:
+            _fix_gemini_schema = staticmethod(lambda schema: schema)
+
+        class ChatGoogle(_BaseChat):
+            pass
+
+        class ChatOllama(_BaseChat):
+            pass
+
+        class ChatOpenRouter(_BaseChat):
+            pass
+
+        class ChatAnthropic(_BaseChat):
+            pass
+
+        class ChatGroq(_BaseChat):
+            pass
+
+        class ChatOpenAI(_BaseChat):
+            pass
+
+        llm_module.ChatGoogle = ChatGoogle
+        llm_module.ChatOllama = ChatOllama
+        llm_module.ChatOpenRouter = ChatOpenRouter
+        llm_module.ChatAnthropic = ChatAnthropic
+        llm_module.ChatGroq = ChatGroq
+        llm_module.ChatOpenAI = ChatOpenAI
+        browser_use.llm = llm_module
+
+        sys.modules["browser_use"] = browser_use
+        sys.modules["browser_use.llm"] = llm_module
+
+    if "faiss" not in sys.modules:
+        faiss_module = types.ModuleType("faiss")
+
+        class _IndexBase:
+            def __init__(self, dim: int):
+                self.dim = dim
+                self._vectors: np.ndarray | None = None
+                self._ids: np.ndarray | None = None
+
+            def add_with_ids(self, matrix: np.ndarray, ids: np.ndarray) -> None:
+                self._vectors = np.asarray(matrix, dtype="float32")
+                self._ids = np.asarray(ids, dtype="int64")
+
+            def search(self, queries: np.ndarray, k: int):
+                if self._vectors is None or self._vectors.size == 0 or self._ids is None:
+                    return (
+                        np.zeros((len(queries), k), dtype="float32"),
+                        -np.ones((len(queries), k), dtype="int64"),
+                    )
+                scores = np.matmul(np.asarray(queries, dtype="float32"), self._vectors.T)
+                order = np.argsort(-scores, axis=1)[:, :k]
+                top_scores = np.take_along_axis(scores, order, axis=1)
+                repeated_ids = np.broadcast_to(self._ids, (len(queries), self._ids.size))
+                top_ids = np.take_along_axis(repeated_ids, order, axis=1)
+                return top_scores.astype("float32"), top_ids.astype("int64")
+
+        class IndexFlatIP(_IndexBase):
+            pass
+
+        class IndexIVFPQ(_IndexBase):
+            def __init__(self, quantizer: Any, dim: int, nlist: int, m: int, bits: int):
+                super().__init__(dim)
+                self.quantizer = quantizer
+
+            def train(self, matrix: np.ndarray) -> None:
+                self._vectors = np.asarray(matrix, dtype="float32")
+                self._ids = np.arange(len(matrix), dtype="int64")
+
+        class IndexIDMap:
+            def __init__(self, index: _IndexBase):
+                self.index = index
+
+            def add_with_ids(self, matrix: np.ndarray, ids: np.ndarray) -> None:
+                self.index.add_with_ids(matrix, ids)
+
+            def search(self, queries: np.ndarray, k: int):
+                return self.index.search(queries, k)
+
+        faiss_module.IndexFlatIP = IndexFlatIP
+        faiss_module.IndexIVFPQ = IndexIVFPQ
+        faiss_module.IndexIDMap = IndexIDMap
+
+        sys.modules["faiss"] = faiss_module
+
+    if "whisper" not in sys.modules:
+        whisper_module = types.ModuleType("whisper")
+
+        class _DummyWhisperModel:
+            def transcribe(self, path: str, fp16: bool = False):
+                return {"text": ""}
+
+        def load_model(name: str, download_root: str | None = None):
+            return _DummyWhisperModel()
+
+        whisper_module.load_model = load_model
+        sys.modules["whisper"] = whisper_module
+
+    if "langchain" not in sys.modules:
+        langchain_module = types.ModuleType("langchain")
+        embeddings_module = types.ModuleType("langchain.embeddings")
+        base_module = types.ModuleType("langchain.embeddings.base")
+        prompts_module = types.ModuleType("langchain.prompts")
+        schema_module = types.ModuleType("langchain.schema")
+
+        class Embeddings:
+            pass
+
+        class ChatPromptTemplate:
+            def __init__(self, messages):
+                self.messages = messages
+
+            @classmethod
+            def from_messages(cls, messages):
+                return cls(messages)
+
+            def __or__(self, other):
+                class _DummyChain:
+                    async def astream(self_inner, _input):
+                        if hasattr(other, "astream"):
+                            async for chunk in other.astream(_input):
+                                yield chunk
+                        else:
+                            if isinstance(other, str):
+                                yield other
+                            else:
+                                yield ""
+
+                return _DummyChain()
+
+        class FewShotChatMessagePromptTemplate:
+            def __init__(self, example_prompt=None, examples=None, input_variables=None):
+                self.example_prompt = example_prompt
+                self.examples = examples or []
+                self.input_variables = input_variables or []
+
+            def format(self, *args, **kwargs):
+                return ""
+
+        class AIMessage:
+            def __init__(self, content: str):
+                self.content = content
+
+        prompts_module.ChatPromptTemplate = ChatPromptTemplate
+        prompts_module.FewShotChatMessagePromptTemplate = FewShotChatMessagePromptTemplate
+        schema_module.AIMessage = AIMessage
+        base_module.Embeddings = Embeddings
+        embeddings_module.base = base_module
+        langchain_module.prompts = prompts_module
+        langchain_module.schema = schema_module
+        langchain_module.embeddings = embeddings_module
+
+        sys.modules["langchain"] = langchain_module
+        sys.modules["langchain.embeddings"] = embeddings_module
+        sys.modules["langchain.embeddings.base"] = base_module
+        sys.modules["langchain.prompts"] = prompts_module
+        sys.modules["langchain.schema"] = schema_module
+
+    if "webcolors" not in sys.modules:
+        webcolors_module = types.ModuleType("webcolors")
+
+        class _RGB:
+            def __init__(self, red: int, green: int, blue: int):
+                self.red = red
+                self.green = green
+                self.blue = blue
+
+        def name_to_rgb(name: str) -> _RGB:
+            return _RGB(255, 255, 255)
+
+        webcolors_module.name_to_rgb = name_to_rgb
+        sys.modules["webcolors"] = webcolors_module
+
+    if "sentence_transformers" not in sys.modules:
+        st_module = types.ModuleType("sentence_transformers")
+
+        class SentenceTransformer:
+            def __init__(self, model: str, **kwargs):
+                self.model = model
+
+            def encode(self, texts, convert_to_numpy: bool = False, batch_size: int = 32):
+                if isinstance(texts, str):
+                    texts = [texts]
+                vectors = np.zeros((len(texts), 768), dtype="float32")
+                if convert_to_numpy:
+                    return vectors
+                return vectors.tolist()
+
+        st_module.SentenceTransformer = SentenceTransformer
+        sys.modules["sentence_transformers"] = st_module
+
+    if "git" not in sys.modules:
+        git_module = types.ModuleType("git")
+
+        class Repo:
+            @staticmethod
+            def init(*args, **kwargs):
+                return Repo()
+
+            @staticmethod
+            def clone_from(*args, **kwargs):
+                return Repo()
+
+        git_module.Repo = Repo
+        sys.modules["git"] = git_module
+
+    if "mcp" not in sys.modules:
+        mcp_module = types.ModuleType("mcp")
+
+        class ClientSession:
+            pass
+
+        class StdioServerParameters:
+            pass
+
+        mcp_module.ClientSession = ClientSession
+        mcp_module.StdioServerParameters = StdioServerParameters
+
+        client_module = types.ModuleType("mcp.client")
+        stdio_module = types.ModuleType("mcp.client.stdio")
+        sse_module = types.ModuleType("mcp.client.sse")
+        streamable_module = types.ModuleType("mcp.client.streamable_http")
+        shared_module = types.ModuleType("mcp.shared")
+        message_module = types.ModuleType("mcp.shared.message")
+        types_module = types.ModuleType("mcp.types")
+
+        def stdio_client(*args, **kwargs):
+            return None
+
+        def sse_client(*args, **kwargs):
+            return None
+
+        def streamablehttp_client(*args, **kwargs):
+            return None
+
+        class SessionMessage:
+            pass
+
+        class CallToolResult:
+            pass
+
+        class ListToolsResult:
+            pass
+
+        stdio_module.stdio_client = stdio_client
+        sse_module.sse_client = sse_client
+        streamable_module.streamablehttp_client = streamablehttp_client
+        message_module.SessionMessage = SessionMessage
+        types_module.CallToolResult = CallToolResult
+        types_module.ListToolsResult = ListToolsResult
+        client_module.stdio = stdio_module
+        client_module.sse = sse_module
+        client_module.streamable_http = streamable_module
+        mcp_module.client = client_module
+        shared_module.message = message_module
+        mcp_module.types = types_module
+
+        sys.modules["mcp"] = mcp_module
+        sys.modules["mcp.client"] = client_module
+        sys.modules["mcp.client.stdio"] = stdio_module
+        sys.modules["mcp.client.sse"] = sse_module
+        sys.modules["mcp.client.streamable_http"] = streamable_module
+        sys.modules["mcp.shared"] = shared_module
+        sys.modules["mcp.shared.message"] = message_module
+        sys.modules["mcp.types"] = types_module
+
+    if "nest_asyncio" not in sys.modules:
+        nest_module = types.ModuleType("nest_asyncio")
+
+        def apply():
+            return None
+
+        nest_module.apply = apply
+        sys.modules["nest_asyncio"] = nest_module
+
+    if "pytz" not in sys.modules:
+        pytz_module = types.ModuleType("pytz")
+
+        class _Timezone:
+            def localize(self, dt, is_dst=False):
+                return dt
+
+        def timezone(name: str) -> _Timezone:
+            return _Timezone()
+
+        pytz_module.timezone = timezone
+        sys.modules["pytz"] = pytz_module

--- a/tests/test_hybrid_retrieval.py
+++ b/tests/test_hybrid_retrieval.py
@@ -1,0 +1,75 @@
+import asyncio
+import os
+import sys
+import time
+
+import numpy as np
+from langchain_core.documents import Document
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from retrieval.hybrid import HybridRetrievalConfig, HybridRetriever
+
+
+class DummyEmbeddings:
+    def embed_query(self, text: str) -> list[float]:
+        seed = max(1, len(text))
+        return [float(((seed + i) % 11) / 10) for i in range(8)]
+
+
+class StubDocStore:
+    def __init__(self, docs: list[Document]):
+        self._docs = {doc.metadata["id"]: doc for doc in docs}
+
+    def get_all_docs(self):
+        return self._docs
+
+
+class StubVectorStore:
+    def __init__(self):
+        self.embeddings = DummyEmbeddings()
+        self._docs = [
+            Document(page_content=f"Synthetic knowledge chunk {idx}", metadata={"id": f"chunk-{idx}", "source": "vector"})
+            for idx in range(6)
+        ]
+        self.db = StubDocStore(self._docs)
+
+    async def search_by_similarity_threshold(self, query: str, limit: int, threshold: float, filter: str = ""):
+        return self._docs[:limit]
+
+
+class StubGraphStore:
+    async def get_related_entities(self, entity_id: str, limit: int = 10):
+        return [
+            {
+                "id": f"{entity_id}-neighbor-{idx}",
+                "content": f"Additional context {idx} for {entity_id}",
+                "source": "graph",
+                "dom_path": f"#node-{idx}",
+            }
+            for idx in range(min(limit, 2))
+        ]
+
+
+def test_hybrid_retrieval_p95_under_4s():
+    retriever = HybridRetriever(
+        agent=None,
+        vector_store=StubVectorStore(),
+        graph_store=StubGraphStore(),
+        config=HybridRetrievalConfig(top_k=3, graph_hops=2, rerank_top_k=5, token_budget=600),
+    )
+
+    async def run_once():
+        result = await retriever.retrieve("test query about hybrid retrieval")
+        assert result.segments, "Expected at least one retrieved segment"
+        assert result.plan.rewritten_queries, "Query planner should provide rewritten queries"
+        assert all(segment.hop >= 0 for segment in result.segments)
+
+    durations: list[float] = []
+    for _ in range(10):
+        start = time.perf_counter()
+        asyncio.run(run_once())
+        durations.append(time.perf_counter() - start)
+
+    percentile = float(np.percentile(np.asarray(durations), 95))
+    assert percentile < 4.0, f"p95 latency {percentile:.2f}s exceeds 4s budget"

--- a/tests/test_litellm_fallback.py
+++ b/tests/test_litellm_fallback.py
@@ -1,0 +1,53 @@
+import os
+import sys
+
+import pytest
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+if TESTS_DIR not in sys.path:
+    sys.path.append(TESTS_DIR)
+
+from dependency_stubs import install_dependency_stubs
+
+
+install_dependency_stubs()
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from models import LiteLLMChatWrapper, ModelConfig, ModelType
+
+
+def _make_wrapper():
+    config = ModelConfig(
+        type=ModelType.CHAT,
+        provider="openai",
+        name="primary",
+        fallbacks=["fallback", "backup"],
+    )
+    return LiteLLMChatWrapper(model=config.name, provider=config.provider, model_config=config)
+
+
+def test_model_sequence_prioritizes_last_successful_and_deprioritizes_failed():
+    wrapper = _make_wrapper()
+
+    # Simulate the primary model failing and the fallback succeeding
+    wrapper._register_failed_model("primary")
+    wrapper._update_successful_model("fallback")
+
+    sequence = wrapper._model_sequence()
+
+    assert sequence[0] == "fallback"
+    assert sequence[-1] == "primary"
+    assert sequence == ["fallback", "backup", "primary"]
+
+
+def test_success_resets_failure_tracking():
+    wrapper = _make_wrapper()
+
+    wrapper._register_failed_model("fallback")
+    assert "fallback" in wrapper._failed_models
+
+    wrapper._update_successful_model("fallback")
+
+    assert "fallback" not in wrapper._failed_models
+    assert wrapper._model_sequence()[0] == "fallback"

--- a/tests/test_system_prompt_overrides.py
+++ b/tests/test_system_prompt_overrides.py
@@ -1,0 +1,75 @@
+import os
+import sys
+
+import pytest
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+if TESTS_DIR not in sys.path:
+    sys.path.append(TESTS_DIR)
+
+from dependency_stubs import install_dependency_stubs
+
+
+install_dependency_stubs()
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from python.extensions.system_prompt import _10_system_prompt as system_prompt_module
+
+
+class DummyAgent:
+    def __init__(self, prompts: dict[str, str] | None = None):
+        self._prompts = prompts or {}
+
+    def read_prompt(self, name: str) -> str:
+        if name not in self._prompts:
+            raise FileNotFoundError(name)
+        return self._prompts[name]
+
+
+@pytest.fixture
+def reset_settings(monkeypatch):
+    original_get_settings = system_prompt_module.get_settings
+    data = {
+        "system_prompt_main_override": "",
+        "system_prompt_user_preferences": "",
+    }
+
+    def fake_settings():
+        return data
+
+    monkeypatch.setattr(system_prompt_module, "get_settings", fake_settings)
+    yield data
+    monkeypatch.setattr(system_prompt_module, "get_settings", original_get_settings)
+
+
+def test_get_main_prompt_uses_default_when_override_missing(reset_settings):
+    agent = DummyAgent({"agent.system.main.md": "default prompt"})
+    assert system_prompt_module.get_main_prompt(agent) == "default prompt"
+
+
+def test_get_main_prompt_prefers_override(reset_settings):
+    agent = DummyAgent({"agent.system.main.md": "default prompt"})
+    reset_settings["system_prompt_main_override"] = "Custom override"
+    assert system_prompt_module.get_main_prompt(agent) == "Custom override"
+
+
+def test_user_preferences_returns_template_when_not_customized(reset_settings):
+    agent = DummyAgent({"agent.system.user-preferences.md": "template text"})
+    assert system_prompt_module.get_user_preferences_prompt(agent) == "template text"
+
+
+def test_user_preferences_uses_custom_text_when_provided(reset_settings):
+    agent = DummyAgent({"agent.system.user-preferences.md": "template text"})
+    reset_settings["system_prompt_user_preferences"] = "User prefers concise replies."
+    assert (
+        system_prompt_module.get_user_preferences_prompt(agent)
+        == "User prefers concise replies."
+    )
+
+
+def test_user_preferences_handles_missing_template(reset_settings):
+    agent = DummyAgent()
+    assert system_prompt_module.get_user_preferences_prompt(agent) == ""
+    reset_settings["system_prompt_user_preferences"] = "Always be kind."
+    assert system_prompt_module.get_user_preferences_prompt(agent) == "Always be kind."

--- a/webui/public/system_prompts.svg
+++ b/webui/public/system_prompts.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="4" width="18" height="16" rx="2" ry="2" stroke="#7C3AED" stroke-width="1.5" fill="white"/>
+  <path d="M6 8H18" stroke="#7C3AED" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M6 12H14" stroke="#7C3AED" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M6 16H12" stroke="#7C3AED" stroke-width="1.5" stroke-linecap="round"/>
+  <circle cx="18" cy="16" r="2" fill="#7C3AED"/>
+</svg>


### PR DESCRIPTION
## Summary
- add configuration fields for fallback chat, utility, and browser models and load them into ModelConfig so LiteLLM chat wrappers can fail over when the primary model fails
- upgrade fastmcp to a Pydantic v2-compatible release and extend the code execution tool timeout to 900 seconds
- introduce a hybrid retrieval module that blends vector search with graph expansion and reranking, along with a performance-focused test

## Testing
- pytest tests/test_hybrid_retrieval.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69121fede4cc83269a8ec5d7cb494183)