### PR TITLE
Handle repeated LLM loops and correct memory backend import

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -333,6 +333,12 @@ class HandledException(Exception):
     pass
 
 
+class AgentPausedException(HandledException):
+    """Raised when the agent intentionally pauses and requires external action."""
+
+    pass
+
+
 class Agent:
 
     DATA_NAME_SUPERIOR = "_superior"
@@ -467,7 +473,9 @@ class Agent:
 
                             if repeat_level >= 4:
                                 self.context.paused = True
-                                return None
+                                raise AgentPausedException(
+                                    "Agent paused after repeated identical responses"
+                                )
 
                         else:  # otherwise proceed with tool
                             self.loop_data.repeat_count = 0


### PR DESCRIPTION
## Summary
- introduce an `AgentPausedException` to signal callers when the agent pauses itself
- raise the new exception when repeated responses trigger a pause so schedulers do not treat the loop as a success path

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69124034db9c83268397742c96d2eacd)