### PR TITLE
Fix MCP server compatibility with FastMCP updates

### DIFF
--- a/prompts/fw.msg_repeat.2.md
+++ b/prompts/fw.msg_repeat.2.md
@@ -1,0 +1,1 @@
+You have repeated the same response again. Change strategies immediately or provide a different action.

--- a/prompts/fw.msg_repeat.3.md
+++ b/prompts/fw.msg_repeat.3.md
@@ -1,0 +1,1 @@
+This is the third identical response in a row. Stop looping, rethink the plan, and take a new action right now.

--- a/prompts/fw.msg_repeat.4.md
+++ b/prompts/fw.msg_repeat.4.md
@@ -1,0 +1,1 @@
+Fourth repeated response detected. The agent is now being paused until a human intervenes with new instructions.

--- a/python/helpers/memory.py
+++ b/python/helpers/memory.py
@@ -29,7 +29,7 @@ from python.helpers import knowledge_import
 from python.helpers.neo4j_memory import Neo4jMemory, list_memory_subdirs
 from python.helpers.log import Log, LogItem
 from enum import Enum
-from agent import Agent, AgentContext
+from agent import Agent, AgentConfig, AgentContext
 import models
 import logging
 from simpleeval import simple_eval


### PR DESCRIPTION
## Summary
- import `AgentConfig` so memory backend selection uses the proper type hints
- track repeated assistant responses, escalate warnings, and pause after the fourth identical reply
- add prompt variants that communicate increasingly urgent guidance when the agent loops
- harden the dynamic MCP proxy so new FastMCP builds without private attributes still boot the UI server

## Testing
- python -m compileall python/helpers/mcp_server.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69123d7482d4832691a14e2501c2040e)